### PR TITLE
fix mask bug in batch setting

### DIFF
--- a/graph_transformer_pytorch/graph_transformer_pytorch.py
+++ b/graph_transformer_pytorch/graph_transformer_pytorch.py
@@ -101,6 +101,8 @@ class Attention(nn.Module):
 
         if exists(mask):
             mask = rearrange(mask, 'b i -> b i ()') & rearrange(mask, 'b j -> b () j')
+            mask = repeat(mask, "b i j -> b num_heads i j", num_heads=self.heads)
+            mask = rearrange(mask, "b heads i j -> (b heads) i j")
             max_neg_value = -torch.finfo(sim.dtype).max
             sim.masked_fill_(~mask, max_neg_value)
 


### PR DESCRIPTION
The original implementation accidentally assumes batch size 1 here, and the mask's batch dimension (1) is automatically broadcast to the # of heads. If batch size is greater than 1, we have to handle that explicitly by copying it once for each head.